### PR TITLE
basics: fix a few typos and edit for clarity

### DIFF
--- a/docs/arithmetics.html
+++ b/docs/arithmetics.html
@@ -98,13 +98,13 @@
     ld a, 3
     ld b, 2
 
-    sub b
+    sub a, b
     ; A = $01, Z reset, C reset
-    sub b
+    sub a, b
     ; A = $FF, Z reset, C set
-    sub $FF
+    sub a, $FF
     ; A = $00, Z set, C reset
-    sub 0
+    sub a, 0
     ; A = $00, Z set, C reset
 </pre>
                 <p>
@@ -124,10 +124,10 @@
 <pre>
     ld a, 42
 
-    cp 10 ; 42 - 10 = 32,  C reset (42 &gt;= 10), Z reset (42 != 10)
+    cp a, 10 ; 42 - 10 = 32,  C reset (42 &gt;= 10), Z reset (42 != 10)
     ; Notice how you can chain comparisons? That comes in handy at times
-    cp 57 ; 42 - 57 = 241, C set   (42 &lt; 57) , Z reset (42 != 57)
-    cp 42 ; 42 - 42 = 0,   C reset (42 &gt;= 42), Z set   (42 == 42)
+    cp a, 57 ; 42 - 57 = 241, C set   (42 &lt; 57) , Z reset (42 != 57)
+    cp a, 42 ; 42 - 42 = 0,   C reset (42 &gt;= 42), Z set   (42 == 42)
 </pre>
                 
                 <h3>Where mah <code>mul</code> and <code>div</code>?</h3>
@@ -141,7 +141,7 @@
     add a, a ; *6
 </pre>
                 <p>
-                    We will program, in a section further up, a function that performs multiplication. Don't worry.
+                    We will program, in a later section, a function that performs multiplication. Don't worry.
                 </p>
                 
                 <h2>Boolean algebra</h2>
@@ -209,7 +209,7 @@
                     This is pretty useful to invert some flags/bits. This is heavily used instead of counters for "flip-flop" states (now you know why a lot of games have two-frame animations!).
                 </p>
                 
-                <h2>BCD</h2>
+                <h2>Binary Coded Decimal (BCD)</h2>
                 <p>
                     Remember how I quickly skimmed over the H and N flags? Let's talk about them. But first, we need to talk about <s><a href="https://www.youtube.com/watch?v=kpk2tdsPh0A">parallel universes</a></s> what BCD is. When you store a number, say 42, you'd usually store it raw -- 42, 0x2A, %00101010. BCD is storing each digit in each nibble -- $42, %01000010. It <em>is</em> less efficient, but much more practical for decimal displaying (instead of dividing by 10, you <code>and a, $0F</code>). Therefore, BCD is better for displaying, but not for calculating: $59 + $01 = $60 and not $5A.
                 </p>

--- a/docs/flags.html
+++ b/docs/flags.html
@@ -36,7 +36,7 @@
                 
                 <h2>The <code>f</code> register</h2>
                 <p>
-                    <code>f</code> being an 8-bit register, it has 8 bits. Bits 0-3 are always zero. Bits 4-7 are called <code>C</code>, <code>H</code>, <code>N</code>, and <code>Z</code>, in that order. Note that, to avoid confusing register <code>c</code> and flag <code>c</code>, flags sometimes get an "<code>f</code>" appended to them (eg. <code>CF</code>, <code>ZF</code>). However, that notation will not work when referencing the flags in the source code &emdash; it's only useful for discussion.
+                    <code>f</code> being an 8-bit register, it has 8 bits. Bits 0-3 are always zero. Bits 4-7 are called <code>C</code>, <code>H</code>, <code>N</code>, and <code>Z</code>, in that order. Note that, to avoid confusing register <code>c</code> and flag <code>c</code>, flags sometimes get an "<code>f</code>" appended to them (eg. <code>CF</code>, <code>ZF</code>). However, that notation will not work when referencing the flags in the source code &mdash; it's only useful for discussion.
                 </p>
                 <p>
                     As always, each of these letters stands for something:

--- a/docs/hello-world.html
+++ b/docs/hello-world.html
@@ -45,7 +45,10 @@
                     Begin the work by creating a directory, anywhere. Call it whatever you want, but <code>hello-world-gb</code> is probably a good pick. Then go into that directory; this is the <b>root</b> of our project. (Everything we'll do will happen inside of the directory.)
                 </p>
                 <p>
-                    Then, download <a href="https://raw.githubusercontent.com/tobiasvl/hardware.inc/master/hardware.inc">this file</a> (right-click, Save As) and save it as <code>hardware.inc</code>. This file contains a lot of definitions that will cut us some work, <i>and</i> standardize the names of the IO registers.
+                    Then, download <a href="https://raw.githubusercontent.com/tobiasvl/hardware.inc/master/hardware.inc">this file</a> (right-click, Save As) and save it as <code>hardware.inc</code> in our project's directory. This file contains a lot of definitions that will cut us some work, <i>and</i> standardize the names of the IO registers.
+                </p>
+                <p>
+                    For the font used in this example, download <a href="res/font.chr">this file</a> (again, right-click, Save As...) and save it as <code>font.chr</code> in the project's directory.
                 </p>
                 <p>
                     Now, create a file, and call it, say, <code>main.asm</code>. We will write all our code in there, starting with the following line: <code>INCLUDE "hardware.inc"</code>. When RGBASM reads this, it will parse <code>hardware.inc</code>'s contents, letting us use all the neat definitions that it contains.
@@ -199,7 +202,7 @@ Start:
                 
                 <h2>Defining data</h2>
                 <p>
-                    Ok, we're almost done. All the code is in place, we just need to give the program the font and the Hello World string. For the font, you need to download <a href="res/font.chr">this file</a> (again, right-click, Save As...), and place it in our Hello World folder. Here's how to use it:
+                    Ok, we're almost done. All the code is in place, we just need to give the program the font and the Hello World string. Remember the font file you downloaded during setup? Here's how to use it:
                 </p>
 <pre>
     jr .lockup

--- a/src/arithmetics.html
+++ b/src/arithmetics.html
@@ -66,13 +66,13 @@
     ld a, 3
     ld b, 2
 
-    sub b
+    sub a, b
     ; A = $01, Z reset, C reset
-    sub b
+    sub a, b
     ; A = $FF, Z reset, C set
-    sub $FF
+    sub a, $FF
     ; A = $00, Z set, C reset
-    sub 0
+    sub a, 0
     ; A = $00, Z set, C reset
 </pre>
 <p>
@@ -92,10 +92,10 @@
 <pre>
     ld a, 42
 
-    cp 10 ; 42 - 10 = 32,  C reset (42 &gt;= 10), Z reset (42 != 10)
+    cp a, 10 ; 42 - 10 = 32,  C reset (42 &gt;= 10), Z reset (42 != 10)
     ; Notice how you can chain comparisons? That comes in handy at times
-    cp 57 ; 42 - 57 = 241, C set   (42 &lt; 57) , Z reset (42 != 57)
-    cp 42 ; 42 - 42 = 0,   C reset (42 &gt;= 42), Z set   (42 == 42)
+    cp a, 57 ; 42 - 57 = 241, C set   (42 &lt; 57) , Z reset (42 != 57)
+    cp a, 42 ; 42 - 42 = 0,   C reset (42 &gt;= 42), Z set   (42 == 42)
 </pre>
 
 <h3>Where mah <code>mul</code> and <code>div</code>?</h3>
@@ -109,7 +109,7 @@
     add a, a ; *6
 </pre>
 <p>
-    We will program, in a section further up, a function that performs multiplication. Don't worry.
+    We will program, in a later section, a function that performs multiplication. Don't worry.
 </p>
 
 <h2>Boolean algebra</h2>
@@ -177,7 +177,7 @@
     This is pretty useful to invert some flags/bits. This is heavily used instead of counters for "flip-flop" states (now you know why a lot of games have two-frame animations!).
 </p>
 
-<h2>BCD</h2>
+<h2>Binary Coded Decimal (BCD)</h2>
 <p>
     Remember how I quickly skimmed over the H and N flags? Let's talk about them. But first, we need to talk about <s><a href="https://www.youtube.com/watch?v=kpk2tdsPh0A">parallel universes</a></s> what BCD is. When you store a number, say 42, you'd usually store it raw -- 42, 0x2A, %00101010. BCD is storing each digit in each nibble -- $42, %01000010. It <em>is</em> less efficient, but much more practical for decimal displaying (instead of dividing by 10, you <code>and a, $0F</code>). Therefore, BCD is better for displaying, but not for calculating: $59 + $01 = $60 and not $5A.
 </p>

--- a/src/flags.html
+++ b/src/flags.html
@@ -4,7 +4,7 @@
 
 <h2>The <code>f</code> register</h2>
 <p>
-    <code>f</code> being an 8-bit register, it has 8 bits. Bits 0-3 are always zero. Bits 4-7 are called <code>C</code>, <code>H</code>, <code>N</code>, and <code>Z</code>, in that order. Note that, to avoid confusing register <code>c</code> and flag <code>c</code>, flags sometimes get an "<code>f</code>" appended to them (eg. <code>CF</code>, <code>ZF</code>). However, that notation will not work when referencing the flags in the source code &emdash; it's only useful for discussion.
+    <code>f</code> being an 8-bit register, it has 8 bits. Bits 0-3 are always zero. Bits 4-7 are called <code>C</code>, <code>H</code>, <code>N</code>, and <code>Z</code>, in that order. Note that, to avoid confusing register <code>c</code> and flag <code>c</code>, flags sometimes get an "<code>f</code>" appended to them (eg. <code>CF</code>, <code>ZF</code>). However, that notation will not work when referencing the flags in the source code &mdash; it's only useful for discussion.
 </p>
 <p>
     As always, each of these letters stands for something:

--- a/src/hello-world.html
+++ b/src/hello-world.html
@@ -13,7 +13,10 @@
     Begin the work by creating a directory, anywhere. Call it whatever you want, but <code>hello-world-gb</code> is probably a good pick. Then go into that directory; this is the <b>root</b> of our project. (Everything we'll do will happen inside of the directory.)
 </p>
 <p>
-    Then, download <a href="https://raw.githubusercontent.com/tobiasvl/hardware.inc/master/hardware.inc">this file</a> (right-click, Save As) and save it as <code>hardware.inc</code>. This file contains a lot of definitions that will cut us some work, <i>and</i> standardize the names of the IO registers.
+    Then, download <a href="https://raw.githubusercontent.com/tobiasvl/hardware.inc/master/hardware.inc">this file</a> (right-click, Save As) and save it as <code>hardware.inc</code> in our project's directory. This file contains a lot of definitions that will cut us some work, <i>and</i> standardize the names of the IO registers.
+</p>
+<p>
+    For the font used in this example, download <a href="res/font.chr">this file</a> (again, right-click, Save As...) and save it as <code>font.chr</code> in the project's directory.
 </p>
 <p>
     Now, create a file, and call it, say, <code>main.asm</code>. We will write all our code in there, starting with the following line: <code>INCLUDE "hardware.inc"</code>. When RGBASM reads this, it will parse <code>hardware.inc</code>'s contents, letting us use all the neat definitions that it contains.
@@ -167,7 +170,7 @@ Start:
 
 <h2>Defining data</h2>
 <p>
-    Ok, we're almost done. All the code is in place, we just need to give the program the font and the Hello World string. For the font, you need to download <a href="res/font.chr">this file</a> (again, right-click, Save As...), and place it in our Hello World folder. Here's how to use it:
+    Ok, we're almost done. All the code is in place, we just need to give the program the font and the Hello World string. Remember the font file you downloaded during setup? Here's how to use it:
 </p>
 <pre>
     jr .lockup


### PR DESCRIPTION
Some minor fixes I made as I went through the basics section of the tutorial.
- `s/&emdash;/&mdash;/`
- don't omit destination register before interlude explanation (e.g. `sub 0` -> `sub a, 0`)
- instruct user to download `font.chr` in setup (I missed that when reading through, easier to download everything at once before the user is trying to understand the assembly)
- a couple of very minor edits for clarity

Looking forward to continuing through the rest of the sections. Thanks for creating the tutorial.