### PR TITLE
Fix bit representation of nibble $B

### DIFF
--- a/src/part1/bin_and_hex.md
+++ b/src/part1/bin_and_hex.md
@@ -90,7 +90,7 @@ This is *much* more compact than binary, and slightly more than decimal, too; bu
      $8 | %1000
      $9 | %1001
      $A | %1010
-     $B | %1010
+     $B | %1011
      $C | %1100
      $D | %1101
      $E | %1110


### PR DESCRIPTION
As identified by MaxGripe on Discord
(https://discord.com/channels/303217943234215948/995647794247372830/998706741426532422)

The bit representation for nibble `$B` was incorrectly using the representation for nibble `$A`. I presume this was a copypaste error. This quick PR fixes this